### PR TITLE
[FEATURE] Add TYPO3 v14 support

### DIFF
--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -120,4 +120,25 @@ ServerName scroll.ddev.site
     Alias "/phpstatus" "/var/www/phpstatus.php"
 </VirtualHost>
 
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    DocumentRoot /var/www/html/v14/public
+    ServerAlias v14.scroll.ddev.site
+
+    <Directory "/var/www/html/v14/">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/.ddev/commands/web/install-all
+++ b/.ddev/commands/web/install-all
@@ -4,3 +4,4 @@ ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_
 
 $ABSOLUTE_PATH/install-v12
 $ABSOLUTE_PATH/install-v13
+$ABSOLUTE_PATH/install-v14

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+VERSION=v14
+
+rm -rf /var/www/html/$VERSION/*
+mkdir -p /var/www/html/$VERSION/
+echo "{}" > /var/www/html/$VERSION/composer.json
+composer config extra.typo3/cms.web-dir public -d /var/www/html/$VERSION
+composer config repositories.$EXTENSION_KEY path ../../$EXTENSION_KEY -d /var/www/html/$VERSION
+composer config --no-plugins allow-plugins.typo3/cms-composer-installers true -d /var/www/html/$VERSION
+composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var/www/html/$VERSION
+# t3/cms has no v14 release (yet), require its package list directly
+composer req typo3/minimal:'^14' typo3/cms-cli:'^3.1' typo3/cms-fluid-styled-content:'^14' typo3/cms-rte-ckeditor:'^14' typo3/cms-belog:'^14' typo3/cms-beuser:'^14' typo3/cms-info:'^14' typo3/cms-install:'^14' typo3/cms-lowlevel:'^14' typo3/cms-setup:'^14' typo3/cms-tstemplate:'^14' helhum/typo3-console $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
+
+cd /var/www/html/$VERSION
+
+mysql -h db -u root -p"root" -e "CREATE DATABASE ${VERSION};"
+
+vendor/bin/typo3 setup -n --dbname=$VERSION --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.scroll.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+
+# v14 setup omits db credentials from settings.php when they come from
+# TYPO3_DB_* environment variables; persist them so the cli works, too
+vendor/bin/typo3 configuration:set 'DB/Connections/Default/host' 'db'
+vendor/bin/typo3 configuration:set 'DB/Connections/Default/port' '3306'
+vendor/bin/typo3 configuration:set 'DB/Connections/Default/dbname' "$VERSION"
+vendor/bin/typo3 configuration:set 'DB/Connections/Default/user' "$TYPO3_DB_USERNAME"
+vendor/bin/typo3 configuration:set 'DB/Connections/Default/password' "$TYPO3_DB_PASSWORD"
+
+vendor/bin/typo3 configuration:set 'BE/debug' 1
+vendor/bin/typo3 configuration:set 'FE/debug' 1
+vendor/bin/typo3 configuration:set 'SYS/devIPmask' '*'
+vendor/bin/typo3 configuration:set 'SYS/displayErrors' 1
+vendor/bin/typo3 configuration:set 'SYS/trustedHostsPattern' '.*.*'
+vendor/bin/typo3 configuration:set 'MAIL/transport' 'smtp'
+vendor/bin/typo3 configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
+vendor/bin/typo3 configuration:set 'MAIL/defaultMailFromAddress' 'admin@example.com'
+vendor/bin/typo3 configuration:set 'GFX/processor' 'ImageMagick'
+vendor/bin/typo3 configuration:set 'GFX/processor_path' '/usr/bin/'
+
+sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/$VERSION/config/system/settings.php
+
+vendor/bin/typo3 cache:flush

--- a/.ddev/commands/web/seed-content
+++ b/.ddev/commands/web/seed-content
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+## Description: Seed demo content for scroll testing (many content elements) into a TYPO3 instance
+## Usage: seed-content [v12|v13|v14]
+## Example: "ddev seed-content v14"
+
+VERSION=${1:-v14}
+
+if [ ! -d /var/www/html/$VERSION/vendor ]; then
+    echo "Instance $VERSION is not installed yet. Run 'ddev install-$VERSION' first."
+    exit 1
+fi
+
+mysql -h db -u root -p"root" $VERSION <<'SQL'
+INSERT INTO pages (pid, title, slug, doktype, sorting, tstamp, crdate)
+SELECT 1, CONCAT('Scroll Demo ', seq), CONCAT('/scroll-demo-', seq), 1, seq * 256, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()
+FROM seq_1_to_3;
+
+INSERT INTO tt_content (pid, colPos, CType, header, bodytext, sorting, tstamp, crdate)
+SELECT p.uid, 0, 'text',
+       CONCAT('Scroll test element ', seq),
+       CONCAT('<p>Demo content #', seq, ' for testing scroll position restore.</p>'),
+       seq * 32, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()
+FROM seq_1_to_40
+JOIN (SELECT uid FROM pages WHERE deleted = 0) p
+WHERE p.uid = 1 OR p.uid IN (SELECT uid FROM pages WHERE slug LIKE '/scroll-demo-%');
+SQL
+
+cd /var/www/html/$VERSION
+vendor/bin/typo3 cache:flush
+
+echo "Seeded 40 content elements each on the root page and 3 demo subpages ($VERSION)."

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -2,6 +2,8 @@ name: scroll
 type: php
 docroot: ""
 no_project_mount: true
+# Mutagen cannot sync a project that is not mounted (no_project_mount)
+performance_mode: none
 php_version: "8.4"
 composer_version: "2"
 webserver_type: apache-fpm
@@ -11,5 +13,6 @@ xdebug_enabled: false
 additional_hostnames:
     - v12.scroll
     - v13.scroll
+    - v14.scroll
 additional_fqdns: []
 use_dns_when_possible: true

--- a/.ddev/docker-compose.web.yaml
+++ b/.ddev/docker-compose.web.yaml
@@ -17,7 +17,7 @@ services:
             - TYPO3_INSTALL_SITE_SETUP_TYPE=site
             - TYPO3_INSTALL_WEB_SERVER_CONFIG=apache
 
-            # TYPO3 v13 config
+            # TYPO3 v13/v14 config
             - TYPO3_DB_DRIVER=mysqli
             - TYPO3_DB_USERNAME=root
             - TYPO3_DB_PASSWORD=root
@@ -34,8 +34,11 @@ services:
               consistency: cached
             - v12-data:/var/www/html/v12
             - v13-data:/var/www/html/v13
+            - v14-data:/var/www/html/v14
 volumes:
     v12-data:
         name: "${DDEV_SITENAME}-v12-data"
     v13-data:
         name: "${DDEV_SITENAME}-v13-data"
+    v14-data:
+        name: "${DDEV_SITENAME}-v14-data"

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -8,6 +8,7 @@ RUN echo "<html><head><style>h2 {display:inline-block;margin-right:0.5em;vertica
 RUN echo "<body><h1>EXT:${EXTENSION_KEY} Dev Environments</h1><ul>" >> /var/www/html/index.html
 RUN echo "<li><h2>TYPO3 12.4 LTS</h2><a href="https://v12.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v12.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
 RUN echo "<li><h2>TYPO3 13.4 LTS</h2><a href="https://v13.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v13.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
+RUN echo "<li><h2>TYPO3 14.3 LTS</h2><a href="https://v14.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v14.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
 RUN echo "</ul>" >> /var/www/html/index.html
 RUN echo "<hr>" >> /var/www/html/index.html
 RUN echo "<h3>TYPO3 Backend</h3><ul><li><b>User:</b> <code>admin</code></li><li><b>Password:</b> <code>Password:joh316</code> (also Install Tool)</li></ul>" >> /var/www/html/index.html
@@ -20,6 +21,9 @@ RUN echo "<h1>Perform this first</h1> <code>ddev install-v12</code>" > /var/www/
 RUN mkdir -p /var/www/html/v13/public/typo3
 RUN echo "<h1>Perform this first</h1> <code>ddev install-v13</code>" > /var/www/html/v13/public/index.html
 RUN echo "<h1>Perform this first</h1> <code>ddev install-v13</code>" > /var/www/html/v13/public/typo3/index.html
+RUN mkdir -p /var/www/html/v14/public/typo3
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v14</code>" > /var/www/html/v14/public/index.html
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v14</code>" > /var/www/html/v14/public/typo3/index.html
 
 ARG uid
 ARG gid

--- a/Classes/EventListener/ModifyPageModuleContentEventListener.php
+++ b/Classes/EventListener/ModifyPageModuleContentEventListener.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace T3\Scroll\EventListener;
 
@@ -9,8 +9,7 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 
 class ModifyPageModuleContentEventListener
 {
-    public function __construct(private readonly PageRenderer $pageRenderer) {
-    }
+    public function __construct(private readonly PageRenderer $pageRenderer) {}
 
     public function __invoke(ModifyPageLayoutContentEvent $event): void
     {

--- a/Classes/EventListener/RecordListScrollHelperEventListener.php
+++ b/Classes/EventListener/RecordListScrollHelperEventListener.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace T3\Scroll\EventListener;
 
@@ -9,8 +9,7 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 
 class RecordListScrollHelperEventListener
 {
-    public function __construct(private readonly PageRenderer $pageRenderer) {
-    }
+    public function __construct(private readonly PageRenderer $pageRenderer) {}
 
     public function __invoke(ModifyRecordListTableActionsEvent $event): void
     {

--- a/Resources/Public/JavaScript/ScrollPageModule.js
+++ b/Resources/Public/JavaScript/ScrollPageModule.js
@@ -3,23 +3,41 @@ if (TYPO3.settings.cache) {
     // v13
     tx_scroll_module = document.querySelector('body > .module > .module-body');
 }
+const tx_scroll_overflowY = tx_scroll_module ? window.getComputedStyle(tx_scroll_module).overflowY : '';
+if (tx_scroll_overflowY !== 'auto' && tx_scroll_overflowY !== 'scroll') {
+    // v14: the module markup does not scroll anymore, the document itself does
+    tx_scroll_module = document.scrollingElement;
+}
 
 /* Prevents jumping after reload*/
 window.location.hash = '';
 
 const uid = new URL(window.location.href).searchParams.get('id') ?? '0';
 
-window.addEventListener('unload', function () {
+window.addEventListener('pagehide', function () {
     sessionStorage.setItem('ext-scroll-pages-' + uid, tx_scroll_module.scrollTop);
 });
 
 const pos = parseInt(sessionStorage.getItem('ext-scroll-pages-' + uid));
 if (pos) {
-    tx_scroll_module.scrollTo(0, pos);
-    // This happens, when the clipboard in V11 (loaded via AJAX) is appearing
+    // behavior 'instant' bypasses the backend's css scroll-behavior:smooth, which
+    // would turn this into an interruptible animation
+    tx_scroll_module.scrollTo({top: pos, behavior: 'instant'});
+    // Content may not be rendered completely yet (module scripts are imported after
+    // the load event, so waiting for it is pointless) - retry for a short while
     if (pos !== tx_scroll_module.scrollTop) {
-        window.addEventListener('load', function () {
-            tx_scroll_module.scrollTo(0, pos);
-        });
+        let timerIterations = 0;
+        const timer = setInterval(function () {
+            tx_scroll_module.scrollTo({top: pos, behavior: 'instant'});
+            if (pos === tx_scroll_module.scrollTop || ++timerIterations > 50) {
+                clearInterval(timer);
+            }
+        }, 40);
+        // Stop fighting the user when they scroll themselves
+        const cancel = function () {
+            clearInterval(timer);
+        };
+        window.addEventListener('wheel', cancel, {once: true, passive: true});
+        window.addEventListener('touchstart', cancel, {once: true, passive: true});
     }
 }

--- a/Resources/Public/JavaScript/ScrollRecordList.js
+++ b/Resources/Public/JavaScript/ScrollRecordList.js
@@ -3,6 +3,11 @@ if (TYPO3.settings.cache) {
     // v13
     tx_scroll_module = document.querySelector('body > .module > .module-body');
 }
+const tx_scroll_overflowY = tx_scroll_module ? window.getComputedStyle(tx_scroll_module).overflowY : '';
+if (tx_scroll_overflowY !== 'auto' && tx_scroll_overflowY !== 'scroll') {
+    // v14: the module markup does not scroll anymore, the document itself does
+    tx_scroll_module = document.scrollingElement;
+}
 
 /* Prevents jumping after reload*/
 window.location.hash = '';
@@ -27,7 +32,7 @@ if (searchTerm !== '') {
     table = 'search-' + searchTerm + '-' + table;
 }
 const storageKey = 'ext-scroll-recordlist-' + table + uid;
-window.addEventListener('unload', function () {
+window.addEventListener('pagehide', function () {
     if (tx_scroll_module.scrollTop > 0) {
         sessionStorage.setItem(storageKey, tx_scroll_module.scrollTop);
     }
@@ -36,20 +41,22 @@ window.addEventListener('unload', function () {
 const pos = parseInt(sessionStorage.getItem(storageKey));
 if (pos) {
     sessionStorage.removeItem(storageKey);
-    tx_scroll_module.scrollTo(0, pos);
+    tx_scroll_module.scrollTo({top: pos, behavior: 'instant'});
     if (pos !== tx_scroll_module.scrollTop) {
-        tx_scroll_module.scrollTo(0, pos);
+        tx_scroll_module.scrollTo({top: pos, behavior: 'instant'});
         if (pos > tx_scroll_module.scrollTop) {
             let timerIterations = 0;
             const timer = setInterval(function () {
                 ++timerIterations;
-                tx_scroll_module.scrollTo(0, pos);
+                tx_scroll_module.scrollTo({top: pos, behavior: 'instant'});
                 if (pos === tx_scroll_module.scrollTop) {
                     clearInterval(timer);
                 }
             }, 20);
 
-            tx_scroll_module.addEventListener('scroll', function () {
+            // Scroll events of document.scrollingElement fire on window, not on the element itself
+            const scrollEventTarget = tx_scroll_module === document.scrollingElement ? window : tx_scroll_module;
+            scrollEventTarget.addEventListener('scroll', function () {
                 if (timerIterations > 20) {
                     clearInterval(timer);
                 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "typo3/cms-core": "^12.4 || ^13.4",
+        "typo3/cms-core": "^12.4 || ^13.4 || ^14.3",
         "typo3/cms-backend": "*"
     },
     "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = array(
     'state' => 'stable',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
+            'typo3' => '12.4.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF[$_EXTKEY] = array(
+$EM_CONF[$_EXTKEY] = [
     'title' => 'Scroll',
     'description' => 'Prevents scroll jumps in TYPO3 CMS backend.',
     'category' => 'backend',
@@ -15,4 +15,4 @@ $EM_CONF[$_EXTKEY] = array(
         'conflicts' => [],
         'suggests' => [],
     ],
-);
+];


### PR DESCRIPTION
This adds TYPO3 v14 compatibility to EXT:scroll, plus a v14 instance for the DDEV environment.

## Extension changes

In TYPO3 v14 the backend module markup does not scroll anymore — the document itself does. Since `TYPO3.settings.cache` still exists in v14, the previous version detection picked the non-scrolling v13 container (`.module-body`, now `overflow: visible`) and the extension silently did nothing.

* The scroll container is now detected by its computed `overflow-y` (v12/v13 keep their previous containers); if none scrolls, `document.scrollingElement` is used (v14)
* Restoring scrolls with `behavior: 'instant'`, because the v14 backend CSS sets `scroll-behavior: smooth`, which turns `scrollTo()` into an interruptible animation
* The page module retries restoring for a short while instead of waiting for the `load` event — module scripts are `import()`ed after `load` has already fired, so the listener never ran
* The deprecated `unload` event is replaced by `pagehide`
* composer.json / ext_emconf.php allow TYPO3 v14

## DDEV environment

* `ddev install-v14` installs a third instance under v14.scroll.ddev.site. The `t3/cms` metapackage has no v14 release yet, so the script requires its package list directly with `^14` constraints
* The v14 `setup` command omits DB credentials from settings.php when they come from `TYPO3_DB_*` env vars (web works, CLI breaks) — they are now persisted explicitly
* New `ddev seed-content <version>` command creates demo pages and content elements, so fresh instances have something to scroll
* `performance_mode: none`: Mutagen cannot sync a project that is not mounted (`no_project_mount`), which broke `ddev start` on macOS hosts with Mutagen enabled globally

## Tested

* v14.3: in a real project backend and in the DDEV v14 instance (page module + record list)
* v13.4: in the DDEV v13 instance
* v12.4: **not tested** — `ddev install-v12` currently fails because Composer's security measures block installing TYPO3 v12 packages with known advisories. The v12 code path is preserved by the feature detection, but could not be verified.